### PR TITLE
Fixing format of codeowners

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,4 +1,2 @@
 #List of main code owners 
-@snarayanan5
-@agrover1
-@vpandeti
+* @snarayanan5 @agrover1 @vpandeti


### PR DESCRIPTION
**Description**

the template was not working.  when a PR was created the codeowners were not listed. I think it was missing the '*' at the beginning of the line

Check the following: 
- [x] The PR is not huge (it has less than a few files, and very few lines of change overall)
- [x] Proper tests are added/updated
- [x] All tests pass and there are no merge conflicts
